### PR TITLE
fix: add max_thinking_tokens limit to prevent extended thinking hangs

### DIFF
--- a/src/claude/client.rs
+++ b/src/claude/client.rs
@@ -220,6 +220,7 @@ impl ClaudeClient {
             .permission_mode(PermissionMode::Default)
             .can_use_tool(can_use_tool)
             .include_partial_messages(true)
+            .max_thinking_tokens(31999)
             .build();
 
         let mut sdk_client = claude_agent_sdk_rs::ClaudeClient::new(options);


### PR DESCRIPTION
## Summary
- Adds `.max_thinking_tokens(31999)` to ClaudeAgentOptions builder
- Prevents the model from spending unlimited time in extended thinking mode
- Matches Claude Code's default behavior in Cursor IDE

## Problem
Without a thinking token limit, simple queries like "How do I get a Discord bot token?" could cause the agent to hang for 2+ minutes while the model thinks indefinitely.

## Solution
Set a 31999 token limit (same as Cursor's default) to cap extended thinking while still allowing substantial reasoning for complex tasks.

## Test plan
- [x] Verify cargo check passes
- [ ] Test with Seren Desktop after rebuilding sidecar
- [ ] Compare response times before/after

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com