### PR TITLE
fix: use SDK with CLAUDE_CLI_PATH priority for reliable CLI discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "claude-agent-sdk-rs"
 version = "0.6.4"
-source = "git+https://github.com/serenorg/claude-agent-sdk-rs#16d826f079d14193680fc08847e42b4f0e5792da"
+source = "git+https://github.com/serenorg/claude-agent-sdk-rs?branch=fix%2Fcli-path-priority#81f3f9a7252c6c2d38c2746d23bf64791528a4f6"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 agent-client-protocol = { version = "0.9", features = ["unstable"] }
 
 # Claude Agent SDK - spawns and communicates with Claude Code CLI
-claude-agent-sdk-rs = { git = "https://github.com/serenorg/claude-agent-sdk-rs" }
+claude-agent-sdk-rs = { git = "https://github.com/serenorg/claude-agent-sdk-rs", branch = "fix/cli-path-priority" }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util", "sync", "time", "process"] }


### PR DESCRIPTION
## Summary

Updates claude-agent-sdk-rs to use the fix/cli-path-priority branch which prioritizes CLAUDE_CLI_PATH environment variable over PATH resolution.

This is part of the fix for seren-desktop#353 where the Claude Agent fails to start with version check errors even when the CLI is installed.

## Changes

- Updated claude-agent-sdk-rs dependency to use fix/cli-path-priority branch

## Related PRs

- seren-desktop PR #354: Sets CLAUDE_CLI_PATH when spawning the sidecar
- claude-agent-sdk-rs: fix/cli-path-priority branch (prioritizes CLAUDE_CLI_PATH)

## Test plan

- [ ] Build seren-acp-claude binary
- [ ] Test with seren-desktop that CLAUDE_CLI_PATH is used correctly

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com