### PR TITLE
fix: send ToolCall instead of ToolCallUpdate for initial tool use

### DIFF
--- a/src/acp/server.rs
+++ b/src/acp/server.rs
@@ -326,15 +326,14 @@ fn convert_claude_message(message: &Message) -> Vec<acp::SessionUpdate> {
                         ))
                     }
                 }
-                ContentBlock::ToolUse(tool_use) => Some(acp::SessionUpdate::ToolCallUpdate(
-                    acp::ToolCallUpdate::new(
+                ContentBlock::ToolUse(tool_use) => Some(acp::SessionUpdate::ToolCall(
+                    acp::ToolCall::new(
                         acp::ToolCallId::new(format!("claude-tool:{}", tool_use.id)),
-                        acp::ToolCallUpdateFields::new()
-                            .title(tool_use.name.clone())
-                            .kind(tool_kind_for_claude_tool(&tool_use.name))
-                            .status(acp::ToolCallStatus::InProgress)
-                            .raw_input(tool_use.input.clone()),
-                    ),
+                        tool_use.name.clone(),
+                    )
+                    .kind(tool_kind_for_claude_tool(&tool_use.name))
+                    .status(acp::ToolCallStatus::InProgress)
+                    .raw_input(tool_use.input.clone()),
                 )),
                 ContentBlock::ToolResult(tool_result) => {
                     let status = if tool_result.is_error.unwrap_or(false) {


### PR DESCRIPTION
## Summary
- `ContentBlock::ToolUse` was emitting `SessionUpdate::ToolCallUpdate` instead of `SessionUpdate::ToolCall`
- The ACP client (seren-desktop) only creates tool cards from `ToolCall` events; `ToolCallUpdate` is for updating existing cards
- This caused all tool activity to be silently dropped — no tool cards ever appeared in Agent mode
- Fix: emit `SessionUpdate::ToolCall` for initial tool use, keep `ToolCallUpdate` for `ContentBlock::ToolResult`

## Context

The ACP protocol defines two notification types:
- **`ToolCall`** — creates a new tool card in the client UI
- **`ToolCallUpdate`** — updates the status of an existing tool card

When Claude uses a tool (Read, Write, Bash, etc.), the SDK sends a `ContentBlock::ToolUse`. This was being converted to `ToolCallUpdate` (status update), but since no `ToolCall` (creation) was sent first, the client had nothing to update.

## Test plan
- [ ] Start an agent session and send a prompt that triggers tool usage
- [ ] Verify ToolCallCard appears for each tool use (Read, Bash, Write, etc.)
- [ ] Verify cards show correct tool name and "InProgress" spinner
- [ ] Verify cards transition to "Completed" or "Failed" when results arrive
- [ ] Verify text and tool cards are interleaved in correct order

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com