### PR TITLE
fix: bump SDK to prioritize CLAUDE_CLI_PATH on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "claude-agent-sdk-rs"
 version = "0.6.5"
-source = "git+https://github.com/serenorg/claude-agent-sdk-rs#5b920400f499f9f45119e2e02cdc6ccaef869963"
+source = "git+https://github.com/serenorg/claude-agent-sdk-rs#8909b526fc01fed6dc136c09b7de6853e7d7c470"
 dependencies = [
  "anyhow",
  "async-stream",


### PR DESCRIPTION
## Summary

- Updates `claude-agent-sdk-rs` from `5b92040` to `8909b52`
- SDK now checks `CLAUDE_CLI_PATH` env var **first** (Strategy 0) instead of last (Strategy 5)
- Fixes OS error 193 on Windows where `find_cli()` resolved a bare `"claude"` name via PATH, bypassing the `.cmd` → `cmd.exe /C` routing in `make_command()`
- Adds diagnostic logging for CLI discovery and version check

## Test plan

- [ ] Windows: verify Claude agent starts successfully with npm-installed CLI (`claude.cmd`)
- [ ] macOS/Linux: verify no regression (agent still starts normally)
- [ ] Check logs show `[SDK] Using CLAUDE_CLI_PATH: ...` when env var is set

Fixes: serenorg/seren-desktop#998

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com